### PR TITLE
Handle csrf token

### DIFF
--- a/python/MISSION/mission-solved.py
+++ b/python/MISSION/mission-solved.py
@@ -25,10 +25,23 @@ SMC_USER = env_lab.SMC.get("username")
 SMC_PASSWORD = env_lab.SMC.get("password")
 SMC_HOST = env_lab.SMC.get("host")
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 
 # Perform the request to login to the SMC
 def login(sw_session, data):
-	
+
+	def set_xsrf_token():
+		"""
+		Sets XSRF request headers for the session if a CSRF token is returned during authentication
+		"""
+		for cookie in response.cookies:
+			if cookie.name == 'XSRF-TOKEN':
+				sw_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+				return
+		return
+
 	print("\n==> Logging in to the SMC")
 	url = f'https://{SMC_HOST}/token/v2/authenticate'
 	response = sw_session.request("POST", url, verify=False, data=data)
@@ -36,6 +49,7 @@ def login(sw_session, data):
 	# If the login was successful
 	if(response.status_code == 200):
 		print(green("Login SUCCESSFUL!"))
+		set_xsrf_token()
 		return True
 	
 	print(red(f'An error has ocurred, while trying to login to SMC, with the following code {response.status_code}'))
@@ -93,6 +107,7 @@ def terminate_session(sw_session):
 	
 	uri = f'https://{SMC_HOST}/token'
 	response = api_session.delete(uri, timeout=30, verify=False)
+	api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # Add the new tag (host group) in the SMC
 def create_new_tag(tag_data):

--- a/python/MISSION/mission.py
+++ b/python/MISSION/mission.py
@@ -25,10 +25,23 @@ SMC_USER = env_lab.SMC.get("username")
 SMC_PASSWORD = env_lab.SMC.get("password")
 SMC_HOST = env_lab.SMC.get("host")
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 
 # Perform the request to login to the SMC
 def login(sw_session, data):
-	
+
+	def set_xsrf_token():
+		"""
+		Sets XSRF request headers for the session if a CSRF token is returned during authentication
+		"""
+		for cookie in response.cookies:
+			if cookie.name == 'XSRF-TOKEN':
+				sw_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+				return
+		return
+
 	print("\n==> Logging in to the SMC")
 	url = f'https://{SMC_HOST}/token/v2/authenticate'
 	env_lab.print_missing_mission_warn(env_lab.get_line())
@@ -102,6 +115,7 @@ def terminate_session(sw_session):
 	
 	uri = f'https://{SMC_HOST}/token'
 	response = api_session.delete(uri, timeout=30, verify=False)
+ 	api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # Add the new tag (host group) in the SMC
 def create_new_tag(tag_data):

--- a/python/add_tag.py
+++ b/python/add_tag.py
@@ -48,6 +48,9 @@ SMC_PASSWORD = ""
 SMC_HOST = ""
 SMC_TENANT_ID = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -65,6 +68,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Set the filter with the request data
     request_data = [
@@ -102,6 +111,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/create_user.py
+++ b/python/create_user.py
@@ -48,6 +48,9 @@ SMC_PASSWORD = "C1sco12345"
 SMC_HOST = "10.10.20.60"
 SMC_TENANT_ID = "132"
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # This is the new user you want to create.
 # Edit the fields as you like.
 newUser = {
@@ -75,6 +78,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     try:
 
@@ -110,6 +119,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_cognitive_intelligence_incidents.py
+++ b/python/get_cognitive_intelligence_incidents.py
@@ -58,6 +58,9 @@ SMC_PASSWORD = ""
 SMC_HOST = ""
 MALICIOUS_IP = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -75,6 +78,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if (response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Get the list of Cognitive Intelligence incidents from the SMC
     url = 'https://' + SMC_HOST + '/sw-reporting/v2/tenants/0/incidents?ipAddress=' + MALICIOUS_IP
@@ -96,6 +105,7 @@ if (response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_flows.py
+++ b/python/get_flows.py
@@ -50,6 +50,9 @@ SMC_PASSWORD = ""
 SMC_HOST = ""
 SMC_TENANT_ID = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 URL = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -68,6 +71,13 @@ response = api_session.request("POST", URL, verify=False, data=login_request_dat
 # If the login was successful
 if response.status_code == 200:
     print("Login successful")
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
+
     # Set the URL for the query to POST the filter and initiate the search
     URL = 'https://' + SMC_HOST + '/sw-reporting/v2/tenants/' + SMC_TENANT_ID + '/flows/queries'
 
@@ -116,6 +126,7 @@ if response.status_code == 200:
 
     URI = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(URI, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_security_events.py
+++ b/python/get_security_events.py
@@ -50,6 +50,9 @@ SMC_HOST = ""
 SMC_TENANT_ID = ""
 MALICIOUS_IP = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -67,6 +70,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Set the URL for the query to POST the filter and initiate the search
     url = 'https://' + SMC_HOST + '/sw-reporting/v1/tenants/' + SMC_TENANT_ID + '/security-events/queries'
@@ -125,6 +134,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_tag_details.py
+++ b/python/get_tag_details.py
@@ -50,6 +50,9 @@ SMC_TENANT_ID = ""
 SMC_MALICIOUS_TAG_ID = ""
 MALICIOUS_IP = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -67,6 +70,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Get the details of a given tag (host group) from the SMC
     url = 'https://' + SMC_HOST + '/smc-configuration/rest/v1/tenants/' + SMC_TENANT_ID + '/tags/' + SMC_MALICIOUS_TAG_ID
@@ -90,6 +99,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_tags.py
+++ b/python/get_tags.py
@@ -48,6 +48,9 @@ SMC_PASSWORD = ""
 SMC_HOST = ""
 SMC_TENANT_ID = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -65,6 +68,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Get the list of tags (host groups) from the SMC
     url = 'https://' + SMC_HOST + '/smc-configuration/rest/v1/tenants/' + SMC_TENANT_ID + '/tags/'
@@ -84,6 +93,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_tenants.py
+++ b/python/get_tenants.py
@@ -47,6 +47,9 @@ SMC_USER = ""
 SMC_PASSWORD = ""
 SMC_HOST = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -64,6 +67,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Get the list of tenants (domains) from the SMC
     url = 'https://' + SMC_HOST + '/sw-reporting/v1/tenants/'
@@ -86,6 +95,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_top_conversations.py
+++ b/python/get_top_conversations.py
@@ -50,6 +50,9 @@ SMC_PASSWORD = ""
 SMC_HOST = ""
 SMC_TENANT_ID = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 URL = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -67,6 +70,12 @@ response = api_session.request("POST", URL, verify=False, data=login_request_dat
 
 # If the login was successful
 if response.status_code == 200:
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Set the URL for the query to POST the filter and initiate the search
     URL = 'https://' + SMC_HOST + '/sw-reporting/v1/tenants/' + SMC_TENANT_ID + '/flow-reports/top-conversations/queries'
@@ -117,6 +126,7 @@ if response.status_code == 200:
 
     URI = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(URI, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_top_ports.py
+++ b/python/get_top_ports.py
@@ -50,6 +50,9 @@ SMC_HOST = ""
 SMC_TENANT_ID = ""
 MALICIOUS_IP = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -67,6 +70,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Set the URL for the query to POST the filter and initiate the search
     url = 'https://' + SMC_HOST + '/sw-reporting/v1/tenants/' + SMC_TENANT_ID + '/flow-reports/top-ports/queries'
@@ -123,6 +132,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/get_users.py
+++ b/python/get_users.py
@@ -48,6 +48,9 @@ SMC_PASSWORD = ""
 SMC_HOST = ""
 SMC_TENANT_ID = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -65,6 +68,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     try:
         # Get the list of users from the SMC
@@ -103,6 +112,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/python/update_tag.py
+++ b/python/update_tag.py
@@ -50,6 +50,9 @@ SMC_TENANT_ID = ""
 SMC_MALICIOUS_TAG_ID = ""
 MALICIOUS_IP = ""
 
+# Stealthwatch Constants
+XSRF_HEADER_NAME = 'X-XSRF-TOKEN'
+
 # Set the URL for SMC login
 url = "https://" + SMC_HOST + "/token/v2/authenticate"
 
@@ -67,6 +70,12 @@ response = api_session.request("POST", url, verify=False, data=login_request_dat
 
 # If the login was successful
 if(response.status_code == 200):
+
+    # Set XSRF token for future requests
+    for cookie in response.cookies:
+        if cookie.name == 'XSRF-TOKEN':
+            api_session.headers.update({XSRF_HEADER_NAME: cookie.value})
+            break
 
     # Get the details of a given tag (host group) from the SMC
     url = 'https://' + SMC_HOST + '/smc-configuration/rest/v1/tenants/' + SMC_TENANT_ID + '/tags/' + SMC_MALICIOUS_TAG_ID
@@ -90,6 +99,7 @@ if(response.status_code == 200):
 
     uri = 'https://' + SMC_HOST + '/token'
     response = api_session.delete(uri, timeout=30, verify=False)
+    api_session.headers.update({XSRF_HEADER_NAME: None})
 
 # If the login was unsuccessful
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests==2.24.0
+xmltodict=0.12.0
+crayons=0.4.0


### PR DESCRIPTION
Starting in v7.3.2, Stealthwatch requires CSRF tokens to be submitted for state-changing HTTP requests.  See details on https://developer.cisco.com/docs/stealthwatch/enterprise/#!how-to-authenticate and on the Reference api pages.

Here, I've updated the sample scripts to add the CSRF token to HTTP requests for systems that require it (e.g. for systems that return a CSRF token during authentication).  Support for pre-7.3.2 releases is retained.

I've tested these changes by running the following scripts against 7.2.1 and 7.3.2 SMCs:
- create_user.py
- MISSION/setup.py